### PR TITLE
fix build tag

### DIFF
--- a/alloc_unix.go
+++ b/alloc_unix.go
@@ -1,4 +1,4 @@
-// +build !windows !appengine
+// +build !windows,!appengine
 
 package stealthpool
 


### PR DESCRIPTION
According to <https://golang.org/cmd/go/#hdr-Build_constraints>

> A build constraint is evaluated as the OR of space-separated options. Each option evaluates as the AND of its comma-separated terms. A file may have multiple build constraints. The overall constraint is the AND of the individual constraints.

So, if `alloc_unix.go` can't be compiled on both windows and appengine, we should use

```go
// +build !windows,!appengine
```

to express

```go
(NOT windows) AND (NOT appengine)
```